### PR TITLE
Adds Google Tag Manager and cookie banner

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ api.get('/start', async (req, res) => {
   const token = jwt.sign({ valid: true }, process.env.jwtsecret);
   const html = templates.indexTemplate({
     title: 'Housing Register Wait Time Search',
-    token
+    token,
+    cookieOptIn: req.cookies['cookie_opt_in'] === true
   });
   res.html(html);
 });

--- a/static/js/cookie-banner.min.js
+++ b/static/js/cookie-banner.min.js
@@ -1,0 +1,1 @@
+"use strict";document.querySelector("[data-behavior=lbh-cookie-close]").addEventListener("click",function(){document.cookie="cookie_opt_in=true;",window.location.reload()});

--- a/templates/partials/footer.hbs
+++ b/templates/partials/footer.hbs
@@ -1,5 +1,9 @@
 </div>
 </div>
+<script type="text/javascript">
+  window.LBHFrontend.initAll();
+</script>
+<script type="text/javascript" src="js/cookie-banner.min.js"></script>
 </body>
 
 </html>

--- a/templates/partials/header.hbs
+++ b/templates/partials/header.hbs
@@ -14,6 +14,7 @@
   <link rel="shortcut icon" href="img/favicon.png" type="image/png" />
   <script type="text/javascript" src="js/lbh-frontend-2.0.0.min.js"></script>
   <script type="text/javascript" src="js/details.polyfill.js"></script>
+  {{#if cookieOptIn}}
   <script type="text/javascript">(function (w, d, s, l, i) {
       w[l] = w[l] || []; w[l].push({
         'gtm.start':
@@ -22,14 +23,35 @@
         j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
           'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
     })(window, document, 'script', 'dataLayer', 'GTM-T7V6KZ4');</script>
+  {{/if}}
   <title>{{title}} | Hackney Council</title>
 </head>
 
 <body class="govuk-template__body">
+  {{#if cookieOptIn}}
   <noscript>
     <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T7V6KZ4" height="0" width="0"
       style="display:none;visibility:hidden"></iframe>
   </noscript>
+  {{/if}}
+  {{#unless cookieOptIn}}
+  <section class="lbh-cookie-banner" data-module="lbh-cookie-banner">
+    <div class="lbh-container">
+      <div class="govuk-grid-row">
+        <div class="lbh-cookie-banner__content govuk-grid-column-two-thirds-from-desktop">
+          We use cookies to ensure you have the best experience. For full details see our <a
+            href="https://hackney.gov.uk/privacy">privacy statement</a>.
+        </div>
+        <div class="lbh-cookie-banner__button-wrapper govuk-grid-column-one-third-from-desktop">
+          <button class="govuk-button lbh-button lbh-button--secondary lbh-cookie-banner__button"
+            data-behavior="lbh-cookie-close">
+            Accept and close
+          </button>
+        </div>
+      </div>
+    </div>
+  </section>
+  {{/unless}}
   <header class="lbh-header">
     <div class="lbh-header__main">
       <div class="lbh-container lbh-header__wrapper">

--- a/templates/partials/header.hbs
+++ b/templates/partials/header.hbs
@@ -14,10 +14,22 @@
   <link rel="shortcut icon" href="img/favicon.png" type="image/png" />
   <script type="text/javascript" src="js/lbh-frontend-2.0.0.min.js"></script>
   <script type="text/javascript" src="js/details.polyfill.js"></script>
+  <script type="text/javascript">(function (w, d, s, l, i) {
+      w[l] = w[l] || []; w[l].push({
+        'gtm.start':
+          new Date().getTime(), event: 'gtm.js'
+      }); var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+          'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', 'GTM-T7V6KZ4');</script>
   <title>{{title}} | Hackney Council</title>
 </head>
 
 <body class="govuk-template__body">
+  <noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T7V6KZ4" height="0" width="0"
+      style="display:none;visibility:hidden"></iframe>
+  </noscript>
   <header class="lbh-header">
     <div class="lbh-header__main">
       <div class="lbh-container lbh-header__wrapper">


### PR DESCRIPTION
**What**
Adds Google Tag Manager and the required cookies approval banner. Google Tag Manager is only initialised if the visitor has chosen to accept cookies.

![image](https://user-images.githubusercontent.com/5405916/85392918-18ff2780-b544-11ea-9310-c6378501efb1.png)

**Why**
So that we can better understand how the wait time tool is being used.