### PR TITLE
Adds expiration to cookie opt-in cookie

### DIFF
--- a/static/js/cookie-banner.min.js
+++ b/static/js/cookie-banner.min.js
@@ -1,1 +1,1 @@
-"use strict";document.querySelector("[data-behavior=lbh-cookie-close]").addEventListener("click",function(){document.cookie="cookie_opt_in=true;",window.location.reload()});
+"use strict";document.querySelector("[data-behavior=lbh-cookie-close]").addEventListener("click",function(){var e=new Date;e.setTime(e.getTime()+24*365*60*60*1e3),document.cookie="cookie_opt_in=true;expires="+e.toUTCString(),window.location.reload()});


### PR DESCRIPTION
**What**
Adds a 365 day expiration to the opt-in cookie so that it persist for as long as the `cookie_banner_seen` cookie does and they remain in sync with one another.

**Why**
At the moment cookie preferences will be forgotten after the tab is closed, however the consent banner will no longer be shown - leading to an odd experience where consent is sought even though the response is not used. 

**Anything else?**
 - The JS for this is minified, so apologies for the awkward reviewing!